### PR TITLE
fix build on Linux 6.0

### DIFF
--- a/mach64_drv.h
+++ b/mach64_drv.h
@@ -40,7 +40,6 @@
 #include <drm/drm_legacy.h>
 #include <drm/drm_print.h>
 #include <drm/drm_ioctl.h>
-#include <drm/drm_irq.h>
 
 /* General customization:
  */

--- a/mach64_state.c
+++ b/mach64_state.c
@@ -898,7 +898,7 @@ int mach64_get_param(struct drm_device *dev, void *data,
 		value = mach64_do_get_frames_queued(dev_priv);
 		break;
 	case MACH64_PARAM_IRQ_NR:
-		value = dev->pdev->irq;
+		value = dev->irq;
 		break;
 	default:
 		return -EINVAL;


### PR DESCRIPTION
The module builds and loads and creates `/dev/dri/card0`, but still untested as I couldn't yet convice Xorg to load `xserver-xorg-video-mach64`.